### PR TITLE
플레이어 Jump state 구현 완료

### DIFF
--- a/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookieJumpState.anim
+++ b/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookieJumpState.anim
@@ -6,7 +6,7 @@ AnimationClip:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: BraveCookieRunState
+  m_Name: BraveCookieJumpState
   serializedVersion: 6
   m_Legacy: 0
   m_Compressed: 0
@@ -20,18 +20,14 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 1042141000, guid: b04833117f747be4c839605c38e86eff, type: 3}
-    - time: 0.055555556
-      value: {fileID: 1917681201, guid: b04833117f747be4c839605c38e86eff, type: 3}
-    - time: 0.11111111
-      value: {fileID: -1307476055, guid: b04833117f747be4c839605c38e86eff, type: 3}
-    - time: 0.16666667
-      value: {fileID: 531969404, guid: b04833117f747be4c839605c38e86eff, type: 3}
+      value: {fileID: -906302997, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 0.125
+      value: {fileID: -50891881, guid: b04833117f747be4c839605c38e86eff, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
     script: {fileID: 0}
-  m_SampleRate: 18
+  m_SampleRate: 8
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
@@ -46,16 +42,14 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 1042141000, guid: b04833117f747be4c839605c38e86eff, type: 3}
-    - {fileID: 1917681201, guid: b04833117f747be4c839605c38e86eff, type: 3}
-    - {fileID: -1307476055, guid: b04833117f747be4c839605c38e86eff, type: 3}
-    - {fileID: 531969404, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: -906302997, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: -50891881, guid: b04833117f747be4c839605c38e86eff, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.22222222
+    m_StopTime: 0.25
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookie_Player.controller
+++ b/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookie_Player.controller
@@ -10,8 +10,10 @@ AnimatorState:
   m_Name: BraveCookieRunState
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
-  m_StateMachineBehaviours: []
+  m_Transitions:
+  - {fileID: -356928367663743844}
+  m_StateMachineBehaviours:
+  - {fileID: 4415185616166712621}
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
   m_WriteDefaultValues: 1
@@ -26,6 +28,59 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1102 &-4621422989180639936
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BraveCookieJumpState
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 1096358834791150366}
+  m_StateMachineBehaviours:
+  - {fileID: 7582949203175354531}
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 6a5c6b9f5527dcb48b32dd9a91edfe0f, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-356928367663743844
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Cookie_Jump
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -4621422989180639936}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.25
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -34,7 +89,13 @@ AnimatorController:
   m_PrefabAsset: {fileID: 0}
   m_Name: BraveCookie_Player
   serializedVersion: 5
-  m_AnimatorParameters: []
+  m_AnimatorParameters:
+  - m_Name: Cookie_Jump
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -60,6 +121,9 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: -8397541120316066142}
     m_Position: {x: 280, y: 110, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -4621422989180639936}
+    m_Position: {x: 540, y: 110, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -67,6 +131,56 @@ AnimatorStateMachine:
   m_StateMachineBehaviours: []
   m_AnyStatePosition: {x: 50, y: 20, z: 0}
   m_EntryPosition: {x: 50, y: 120, z: 0}
-  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ExitPosition: {x: 950, y: 60, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: -8397541120316066142}
+--- !u!1101 &1096358834791150366
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Cookie_Jump
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -8397541120316066142}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!114 &4415185616166712621
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c97fe7317b868244e9a587661a0e44b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &7582949203175354531
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f66d3f58eb6b6344bcc75177bb00fdb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _jumpPower: 5

--- a/CookieRun/Assets/Scenes/SampleScene.unity
+++ b/CookieRun/Assets/Scenes/SampleScene.unity
@@ -220,6 +220,7 @@ GameObject:
   - component: {fileID: 384223312}
   - component: {fileID: 384223311}
   - component: {fileID: 384223310}
+  - component: {fileID: 384223315}
   m_Layer: 0
   m_Name: BraveCookie_Player
   m_TagString: Untagged
@@ -360,8 +361,20 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &384223315
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 384223309}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96c88c2c1e9706a479e9f782d0e96539, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &431116093
 GameObject:
   m_ObjectHideFlags: 0
@@ -396,7 +409,7 @@ Transform:
   m_Children:
   - {fileID: 469400861}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &431116095
 SpriteRenderer:
@@ -1112,7 +1125,7 @@ GameObject:
   - component: {fileID: 1225822159}
   m_Layer: 0
   m_Name: Floor
-  m_TagString: Untagged
+  m_TagString: Floor
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/CookieRun/Assets/Scripts/BraveCookie.cs
+++ b/CookieRun/Assets/Scripts/BraveCookie.cs
@@ -2,11 +2,13 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class BraveCookie : PlayerController
+public class BraveCookie : MonoBehaviour
 {
+    Animator animator;
+
     void Start()
     {
-        PlayerHP();
+        animator = GetComponent<Animator>();
     }
 
     // Update is called once per frame
@@ -15,8 +17,12 @@ public class BraveCookie : PlayerController
 
     }
 
-    public override void PlayerHP()
+    private void OnCollisionEnter2D(Collision2D collision)
     {
-        base.PlayerHP();
+        if (collision.gameObject.CompareTag("Floor"))
+        {
+            animator.SetBool("Cookie_Jump", false);
+        }
+        
     }
 }

--- a/CookieRun/Assets/Scripts/JumpState.cs
+++ b/CookieRun/Assets/Scripts/JumpState.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class JumpState : StateMachineBehaviour
+{
+    private Vector2 _jump = Vector2.up;
+    [SerializeField]private float _jumpPower;
+    private Rigidbody2D _rigidbody2D;
+
+
+    override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+        _rigidbody2D = animator.GetComponent<Rigidbody2D>();
+        _rigidbody2D.AddForce(_jump * _jumpPower, ForceMode2D.Impulse);
+    }
+
+    override public void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+        
+    }
+
+    override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+
+    }
+   
+}

--- a/CookieRun/Assets/Scripts/RunState.cs
+++ b/CookieRun/Assets/Scripts/RunState.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RunState : StateMachineBehaviour
+{
+    override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+
+    }
+
+    override public void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+        if(Input.GetKeyDown(KeyCode.W)) 
+        {
+            animator.SetBool("Cookie_Jump", true);
+        }
+    }
+
+    override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+
+    }
+
+}

--- a/CookieRun/ProjectSettings/TagManager.asset
+++ b/CookieRun/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Floor
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
1. PlayController 스크립트 내용은 Game Manager가 괸리하는게 맞다고 판단해서 BraveCookie한테 상속을 하지 않음.

2. 원작을 보니 BraveCookie 달리기가 빨라서 달리는 애니메이션을 속도가 빠르게 보이도록 수정함

# PR을 하기 전 체크사항
PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다.

<!-- 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요 -->
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능

- 플레이어가 w키를 입력 받으면 점프한다.
- BraveCookie는 PlayerController를 상속 받지 않는다.

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- StateMachineBehaviour를 사용해서 현재 플레이어에 상태를 알려줬다.
> 플레이어가 점프한 상태를 가독성과 코드의 안정성을 고려했다.

# (선택)스크린샷
![bandicam_2023-04-20_09-06-17-809_AdobeExpress](https://user-images.githubusercontent.com/120005332/233225769-3ddd5ea8-d14f-4dc5-b604-d4932b7a3656.gif)


