### PR TITLE
Double Jump 구현

### DIFF
--- a/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookieDoubleJumpState.anim
+++ b/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookieDoubleJumpState.anim
@@ -1,0 +1,116 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BraveCookieDoubleJumpState
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 1586685051, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 0.1
+      value: {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 0.2
+      value: {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 0.3
+      value: {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 0.4
+      value: {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 0.5
+      value: {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 0.6
+      value: {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 0.7
+      value: {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 0.8
+      value: {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 0.9
+      value: {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 1
+      value: {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 1.1
+      value: {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 1.2
+      value: {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 1.3
+      value: {fileID: 773403472, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 1.4
+      value: {fileID: 773403472, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 1.5
+      value: {fileID: 1925978555, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 1.6
+      value: {fileID: 1925978555, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 10
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 1586685051, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: 773403472, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: 773403472, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: 1925978555, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: 1925978555, guid: b04833117f747be4c839605c38e86eff, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.7
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookie_Player.controller
+++ b/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookie_Player.controller
@@ -28,6 +28,31 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-7781141028383680695
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Dobule_Jump
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -1208202914345183775}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &-4621422989180639936
 AnimatorState:
   serializedVersion: 6
@@ -40,6 +65,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 1096358834791150366}
+  - {fileID: -7781141028383680695}
   m_StateMachineBehaviours:
   - {fileID: 7582949203175354531}
   m_Position: {x: 50, y: 50, z: 0}
@@ -51,6 +77,34 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: 6a5c6b9f5527dcb48b32dd9a91edfe0f, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-1208202914345183775
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BraveCookieDoubleJumpState
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 8986879817101830261}
+  m_StateMachineBehaviours:
+  - {fileID: 6657254145576099943}
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 0c00b4723cd9e2044a437007779b97a1, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 
@@ -95,7 +149,13 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
+  - m_Name: Dobule_Jump
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -124,6 +184,9 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: -4621422989180639936}
     m_Position: {x: 540, y: 110, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -1208202914345183775}
+    m_Position: {x: 540, y: 0, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -171,6 +234,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c97fe7317b868244e9a587661a0e44b5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &6657254145576099943
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a32b812d73219b54fb48968d5355f0b8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _doubleJumpPower: 4
 --- !u!114 &7582949203175354531
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -183,4 +259,29 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5f66d3f58eb6b6344bcc75177bb00fdb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _jumpPower: 5
+  _jumpPower: 6.3
+--- !u!1101 &8986879817101830261
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Dobule_Jump
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -8397541120316066142}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.8076923
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1

--- a/CookieRun/Assets/Scenes/SampleScene.unity
+++ b/CookieRun/Assets/Scenes/SampleScene.unity
@@ -287,7 +287,7 @@ BoxCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 2.7100003, y: 2.84073}
+    oldSize: {x: 2.73, y: 2.7907171}
     newSize: {x: 2.7100003, y: 2.84073}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
@@ -356,7 +356,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 384223309}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -2.266, y: -1.352, z: 0}
+  m_LocalPosition: {x: -2.05, y: -1.37, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/CookieRun/Assets/Scripts/BraveCookie.cs
+++ b/CookieRun/Assets/Scripts/BraveCookie.cs
@@ -22,6 +22,7 @@ public class BraveCookie : MonoBehaviour
         if (collision.gameObject.CompareTag("Floor"))
         {
             animator.SetBool("Cookie_Jump", false);
+            animator.SetBool("Dobule_Jump", false);
         }
         
     }

--- a/CookieRun/Assets/Scripts/DobuleJump.cs
+++ b/CookieRun/Assets/Scripts/DobuleJump.cs
@@ -2,30 +2,25 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class JumpState : StateMachineBehaviour
+public class DobuleJump : StateMachineBehaviour
 {
-    private Vector2 _jump = Vector2.up;
-    [SerializeField]private float _jumpPower;
     private Rigidbody2D _rigidbody2D;
-
-
+    private Vector2 _doubleJump = Vector2.up;
+    [SerializeField]private float _doubleJumpPower;
     override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         _rigidbody2D = animator.GetComponent<Rigidbody2D>();
-        _rigidbody2D.AddForce(_jump * _jumpPower, ForceMode2D.Impulse);
+        _rigidbody2D.AddForce(_doubleJump * _doubleJumpPower, ForceMode2D.Impulse);
     }
 
     override public void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
-        if (Input.GetKeyDown(KeyCode.W))
-        {
-            animator.SetBool("Dobule_Jump", true);
-        }
+
     }
 
     override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
 
     }
-   
+
 }


### PR DESCRIPTION
1. 더블 점프를 구현했다.
2. 점프인 상태에서만 가능하다.

# PR을 하기 전 체크사항
PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다.

<!-- 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요 -->
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능

- 더블 점프가 가능하다.

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- Double Jump 애니메이션을 추가하고, StateMachineBehaviour을 사용해서 더블 점프 할 때 추가적인 힘을 주도록 만들었다.
> 더블 점프는 기존 점프에서 추가적인 힘을 더 받아서 높게 뛰어야하기 때문에 상태 전달을 용이하게 하기 위해  StateMachineBehaviour을 사용했고, 높게 뛰게 만들기 위해 추가적인 힘을 주었다.


# (선택)스크린샷


![bandicam_2023-04-20_10-08-01-023_AdobeExpress](https://user-images.githubusercontent.com/120005332/233232369-7c1e64bc-eac9-4aa9-81e7-449fe00300ed.gif)

