### PR TITLE
slide 상태 구현 완료

### DIFF
--- a/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookieDoubleJumpState.anim
+++ b/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookieDoubleJumpState.anim
@@ -22,36 +22,38 @@ AnimationClip:
     - time: 0
       value: {fileID: 1586685051, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - time: 0.1
-      value: {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
+      value: {fileID: 1586685051, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - time: 0.2
-      value: {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
+      value: {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - time: 0.3
-      value: {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
+      value: {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - time: 0.4
-      value: {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
+      value: {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - time: 0.5
-      value: {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
+      value: {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - time: 0.6
-      value: {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
+      value: {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - time: 0.7
-      value: {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
+      value: {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - time: 0.8
-      value: {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
-    - time: 0.9
-      value: {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
-    - time: 1
       value: {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
-    - time: 1.1
+    - time: 0.9
       value: {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
-    - time: 1.2
+    - time: 1
       value: {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 1.1
+      value: {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 1.2
+      value: {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - time: 1.3
-      value: {fileID: 773403472, guid: b04833117f747be4c839605c38e86eff, type: 3}
+      value: {fileID: 1737982175, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - time: 1.4
       value: {fileID: 773403472, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - time: 1.5
-      value: {fileID: 1925978555, guid: b04833117f747be4c839605c38e86eff, type: 3}
+      value: {fileID: 773403472, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - time: 1.6
+      value: {fileID: 1925978555, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 1.7
       value: {fileID: 1925978555, guid: b04833117f747be4c839605c38e86eff, type: 3}
     attribute: m_Sprite
     path: 
@@ -72,6 +74,7 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
+    - {fileID: 1586685051, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - {fileID: 1586685051, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - {fileID: -1125616988, guid: b04833117f747be4c839605c38e86eff, type: 3}
     - {fileID: 746073599, guid: b04833117f747be4c839605c38e86eff, type: 3}
@@ -94,7 +97,7 @@ AnimationClip:
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1.7
+    m_StopTime: 1.8000001
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookieSlideState.anim
+++ b/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookieSlideState.anim
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BraveCookieSlideState
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: -2042879189, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 0.083333336
+      value: {fileID: -755761480, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 12
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: -2042879189, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: -755761480, guid: b04833117f747be4c839605c38e86eff, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.16666667
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookie_Player.controller
+++ b/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookie_Player.controller
@@ -12,6 +12,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: -356928367663743844}
+  - {fileID: 3813139170577751486}
   m_StateMachineBehaviours:
   - {fileID: 4415185616166712621}
   m_Position: {x: 50, y: 50, z: 0}
@@ -23,6 +24,34 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 7400000, guid: c6e09a7075cd0514897201d5b6117557, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &-7995576907812811186
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BraveCookieSlideState
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 7186077687756102212}
+  m_StateMachineBehaviours:
+  - {fileID: 7144257191009477990}
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: b2f55e4fe3f515644a73b574077b00de, type: 2}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 
@@ -156,6 +185,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
+  - m_Name: Cookie_Slide
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -187,6 +222,9 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: -1208202914345183775}
     m_Position: {x: 540, y: 0, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -7995576907812811186}
+    m_Position: {x: 280, y: 220, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -210,6 +248,31 @@ AnimatorStateTransition:
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -8397541120316066142}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &3813139170577751486
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Cookie_Slide
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -7995576907812811186}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
@@ -247,6 +310,43 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _doubleJumpPower: 4
+--- !u!114 &7144257191009477990
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a746c426d046d44da2b746e0b8478db, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1101 &7186077687756102212
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Cookie_Slide
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -8397541120316066142}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!114 &7582949203175354531
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/CookieRun/Assets/Scenes/SampleScene.unity
+++ b/CookieRun/Assets/Scenes/SampleScene.unity
@@ -283,18 +283,18 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.028318405, y: -0.61471444}
+  m_Offset: {x: 0, y: -0.6}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 2.73, y: 2.7907171}
+    oldSize: {x: 2.7100003, y: 2.84073}
     newSize: {x: 2.7100003, y: 2.84073}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1.167449, y: 1.3714026}
+  m_Size: {x: 1.1, y: 1.35}
   m_EdgeRadius: 0
 --- !u!212 &384223313
 SpriteRenderer:

--- a/CookieRun/Assets/Scripts/RunState.cs
+++ b/CookieRun/Assets/Scripts/RunState.cs
@@ -1,9 +1,11 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Animations;
 
 public class RunState : StateMachineBehaviour
 {
+    
     override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
 
@@ -11,9 +13,18 @@ public class RunState : StateMachineBehaviour
 
     override public void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
+        // Cookie 점프
         if(Input.GetKeyDown(KeyCode.W)) 
         {
             animator.SetBool("Cookie_Jump", true);
+        }
+
+        // Cookie 슬라이드
+        // 누르고 있을 땐 계속 Slide가 진행되도록 설정한다.
+        if(Input.GetKey(KeyCode.S))
+        {
+            animator.SetBool("Cookie_Slide", true);
+            
         }
     }
 

--- a/CookieRun/Assets/Scripts/SlideState.cs
+++ b/CookieRun/Assets/Scripts/SlideState.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SlideState : StateMachineBehaviour
+{
+    private BoxCollider2D _boxCollider2D;
+
+    // slide 충돌 범위 및 offset 
+    private Vector2 _slideOffset = new Vector2(0f, -0.95f);
+    private Vector2 _slideSize = new Vector2(1.1f, 0.675f);
+    
+    private Vector2 _originColliderSize;
+    private Vector2 _originOffset;
+
+    override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+        _boxCollider2D = animator.GetComponent<BoxCollider2D>();
+
+        // 기본 상태 충돌 범위 및 offset
+        _originColliderSize = _boxCollider2D.size;
+        _originOffset = _boxCollider2D.offset;
+
+        // slide 충돌 범위 및 offset 
+        _boxCollider2D.size = _slideSize;
+        _boxCollider2D.offset = _slideOffset;
+    }
+    override public void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+        // S키를 때면 Slide를 멈추고 다시 달리는 상태로 전환한다.
+        if (Input.GetKeyUp(KeyCode.S))
+        {
+            animator.SetBool("Cookie_Slide", false);
+        }
+
+    }
+    override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    {
+        // 슬라이드가 끝나면 기본 상태 충돌 범위, offset으로 돌려 놓는다.
+        _boxCollider2D.size = _originColliderSize;
+        _boxCollider2D.offset = _originOffset;
+    }
+
+}


### PR DESCRIPTION
1. slide 할 때 충돌 범위를 조절했다.

2. slide 상태가 끝났을 때 다시 원래 충돌 범위로 돌려놓았다.

# PR을 하기 전 체크사항
PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다.

<!-- 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요 -->
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
달라진 기능에는 무엇이 있는지 목록으로 작성합니다.

-  slide 상태
- slide 상태일 때 충돌 범위도 slide된 캐릭터 범위만큼 조절된다.

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- slide state 클래스를 추가했습니다.
> slide state 클래스를 추가해서  캐릭터가 slide된 상태를 통제할 수 있게 만들었습니다.

# (선택)스크린샷
![Slide 충돌 범위 해결](https://user-images.githubusercontent.com/120005332/233305134-9711b9d6-d3a7-4e80-b683-a98e956e7980.gif)
