### PR TITLE
takeDamage 상태 구현

### DIFF
--- a/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookieTakeDamageState.anim
+++ b/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookieTakeDamageState.anim
@@ -1,0 +1,74 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BraveCookieTakeDamageState
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: -797235518, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 0.125
+      value: {fileID: -1301713605, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - time: 0.25
+      value: {fileID: -1057161943, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 8
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: -797235518, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: -1301713605, guid: b04833117f747be4c839605c38e86eff, type: 3}
+    - {fileID: -1057161943, guid: b04833117f747be4c839605c38e86eff, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.375
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookie_Player.controller
+++ b/CookieRun/Assets/Animation/BraveCookie_Player/BraveCookie_Player.controller
@@ -7,7 +7,7 @@ AnimatorState:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: BraveCookieRunState
+  m_Name: Run
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
@@ -36,7 +36,7 @@ AnimatorState:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: BraveCookieSlideState
+  m_Name: Slide
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
@@ -89,7 +89,7 @@ AnimatorState:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: BraveCookieJumpState
+  m_Name: Jump
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
@@ -118,7 +118,7 @@ AnimatorState:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: BraveCookieDoubleJumpState
+  m_Name: Double Jump
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions:
@@ -191,6 +191,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
+  - m_Name: Cookie_TakeDamge
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -221,12 +227,16 @@ AnimatorStateMachine:
     m_Position: {x: 540, y: 110, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -1208202914345183775}
-    m_Position: {x: 540, y: 0, z: 0}
+    m_Position: {x: 440, y: -60, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -7995576907812811186}
     m_Position: {x: 280, y: 220, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 3311526974557038623}
+    m_Position: {x: 130, y: -80, z: 0}
   m_ChildStateMachines: []
-  m_AnyStateTransitions: []
+  m_AnyStateTransitions:
+  - {fileID: 938076570298061561}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
@@ -235,6 +245,31 @@ AnimatorStateMachine:
   m_ExitPosition: {x: 950, y: 60, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: -8397541120316066142}
+--- !u!1101 &938076570298061561
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Cookie_TakeDamge
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 3311526974557038623}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.75
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &1096358834791150366
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -260,6 +295,55 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1102 &3311526974557038623
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Take Damage
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 3944501456582514428}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: d4630889fb9f2a44c826c2295b0974e4, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &3398477237458639938
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -8397541120316066142}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.3333333
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &3813139170577751486
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -281,6 +365,28 @@ AnimatorStateTransition:
   m_TransitionOffset: 0
   m_ExitTime: 0
   m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &3944501456582514428
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -8397541120316066142}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.3333333
+  m_HasExitTime: 1
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1

--- a/CookieRun/Assets/Resources/New Folder/Test.asset
+++ b/CookieRun/Assets/Resources/New Folder/Test.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 0}
+  m_Name: Test
+  m_EditorClassIdentifier: Assembly-CSharp::Testsss
+  a: 0
+  b: 0
+  c: 0
+  d: 0

--- a/CookieRun/Assets/Scenes/SampleScene.unity
+++ b/CookieRun/Assets/Scenes/SampleScene.unity
@@ -1113,6 +1113,139 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1161552783
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1161552787}
+  - component: {fileID: 1161552786}
+  - component: {fileID: 1161552785}
+  - component: {fileID: 1161552784}
+  m_Layer: 0
+  m_Name: Triangle
+  m_TagString: Obstacles
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &1161552784
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1161552783}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: -0.02099359, y: 0.06437817}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.28866667}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.53814054, y: 0.7060897}
+  m_EdgeRadius: 0
+--- !u!50 &1161552785
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1161552783}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!212 &1161552786
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1161552783}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
+  m_Sprite: {fileID: 7482667652216324306, guid: 75f5f34dc1b5347e0b8351032682f224, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1161552787
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1161552783}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.66, y: -0.24, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1225822157
 GameObject:
   m_ObjectHideFlags: 0

--- a/CookieRun/Assets/Scripts/BraveCookie.cs
+++ b/CookieRun/Assets/Scripts/BraveCookie.cs
@@ -1,14 +1,18 @@
+using PlayerAnimationID;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class BraveCookie : MonoBehaviour
+public class BraveCookie : PlayerController
 {
     Animator animator;
+    
 
-    void Start()
+    private void Start()
     {
         animator = GetComponent<Animator>();
+        PlayerHP(100);
+        _invicible = false;
     }
 
     // Update is called once per frame
@@ -17,13 +21,31 @@ public class BraveCookie : MonoBehaviour
 
     }
 
+    public override void PlayerHP(int Health)
+    {
+        base.PlayerHP(Health);
+    }
+
+    public override void PlayerTakeDamageState(int damage)
+    {
+        base.PlayerTakeDamageState(10);
+    }
+
     private void OnCollisionEnter2D(Collision2D collision)
     {
         if (collision.gameObject.CompareTag("Floor"))
         {
-            animator.SetBool("Cookie_Jump", false);
-            animator.SetBool("Dobule_Jump", false);
+            animator.SetBool(PlayerAniID.IS_Jumping, false);
+            animator.SetBool(PlayerAniID.IS_DobuleJumping, false);
         }
-        
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.CompareTag("Obstacles") && !_invicible)
+        {
+            animator.SetTrigger(PlayerAniID.IS_TakeDamage);
+            PlayerTakeDamageState(10);
+        }
     }
 }

--- a/CookieRun/Assets/Scripts/JumpState.cs
+++ b/CookieRun/Assets/Scripts/JumpState.cs
@@ -1,3 +1,4 @@
+using PlayerAnimationID;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -19,7 +20,7 @@ public class JumpState : StateMachineBehaviour
     {
         if (Input.GetKeyDown(KeyCode.W))
         {
-            animator.SetBool("Dobule_Jump", true);
+            animator.SetBool(PlayerAniID.IS_DobuleJumping, true);
         }
     }
 

--- a/CookieRun/Assets/Scripts/PlayerAnimationID/PlayerAnimationID.cs
+++ b/CookieRun/Assets/Scripts/PlayerAnimationID/PlayerAnimationID.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace PlayerAnimationID
+{
+    class PlayerAniID
+    {
+        public static readonly int IS_Jumping = Animator.StringToHash("Cookie_Jump");
+        public static readonly int IS_DobuleJumping = Animator.StringToHash("Dobule_Jump");
+        public static readonly int IS_Slide = Animator.StringToHash("Cookie_Slide");
+        public static readonly int IS_TakeDamage = Animator.StringToHash("Cookie_TakeDamge");
+    }
+}

--- a/CookieRun/Assets/Scripts/PlayerController.cs
+++ b/CookieRun/Assets/Scripts/PlayerController.cs
@@ -3,31 +3,120 @@ using System.Collections.Generic;
 using Unity.VisualScripting;
 using UnityEngine;
 
+//스크립트 생성
+//[System.Serializable]
+//public class CookieData
+//{
+//    public int hp;
+//}
+
+//스크립트 생성
+//public class CookieResourceData
+//{
+//    public string animationPath;
+//}
+
+//스크립트 생성
+
+//[CreateAssetMenu(fileName = "Test", menuName = "Test/Test")]
+//public class Testsss : ScriptableObject
+//{
+//    public CookieData data;
+//    public CookieResourceData data2;
+//}
+
+//public class Cookie
+//{
+//    CookieData data;
+
+//    public Init(CookieData data, CookieResourceData data2)
+//    {
+//        this.data = data;
+//    }
+//}
+
 public class PlayerController : MonoBehaviour
 {
+    // 플레이어 체력 1초마다 1씩 감소
     protected int HP;
     IEnumerator playerHealthDecrease;
     WaitForSeconds waitForSeconds = new WaitForSeconds(1);
 
+    // 플레이어 무적 상태
+    //IEnumerator InvicibleState;
+    WaitForSeconds InvicibleWaitForSeconds = new WaitForSeconds(3);
+    protected bool _hurt;
+    protected bool _invicible;
+
+    // 플레이어의 무적상태를 Alpha를 통해 알려준다.
+    //IEnumerator Alpha;
+    WaitForSeconds AlphaSeconds = new WaitForSeconds(0.1f);
+    protected SpriteRenderer _spriteRenderer;
+    protected Color _halfAlpha = new Color(1, 1, 1, 0.5f);
+    protected Color _fullAlpha = new Color(1, 1, 1, 1);
+
     // BraveCookie에서 코루틴을 Start에서 실행하기 때문에, 같이 Start 함수에 작성하면 로직이 꼬이게 된다.
     // 그래서 그런 버그를 방지하기 위해 Awake 함수에 작성한다.
+    // 상속 받은 BraveCookie에서 Awake에 컴포넌트를 참조 받는다면 routine is null 이라는 오류가 발생한다.
+    // BraveCookie는 Awake에서 참조를 받으면 playerHealthDecrease와 로직이 겹쳐서 에러가 발생한다.
     private void Awake()
     {
         playerHealthDecrease = PlayerHealthDecrease();
+        //InvicibleState = Invicible();
+        //Alpha = AlphaBlink();
+
+        _spriteRenderer = GetComponent<SpriteRenderer>();
+        //Debug.Log(Resources.Load<타입>("경로");
     }
-    public virtual void PlayerHP()
+    public virtual void PlayerHP(int Health)
     {
-        HP = 100;
+        HP = Health;
         StartCoroutine(playerHealthDecrease);
+    }
+
+    public virtual void PlayerTakeDamageState(int damage)
+    {
+        if (!_hurt)
+        {
+            HP -= damage;
+            _hurt = true;
+            _invicible = true;
+            StartCoroutine(Invicible());
+            StartCoroutine(AlphaBlink());
+            Debug.Log("무적 상태");
+        }
     }
     // 코루틴
     // 1초마다 플레이어 체력을 1씩 감소시킨다.
     IEnumerator PlayerHealthDecrease()
     {
-        while(HP > 0)
+        while (HP > 0)
         {
             yield return waitForSeconds;
             HP -= 1;
+            Debug.Log("-1 감소");
+        }
+    }
+
+    // 무적상태 코루틴
+    IEnumerator Invicible()
+    {
+        yield return InvicibleWaitForSeconds;
+        _hurt = false;
+        _invicible = false;
+        Debug.Log("Invicible 코루틴");
+    }
+
+    // 무적상태를 Sprite Render로 알려주는 코루틴
+    IEnumerator AlphaBlink()
+    {
+        while (_hurt)
+        {
+            yield return AlphaSeconds;
+            _spriteRenderer.color = _halfAlpha;
+
+            yield return AlphaSeconds;
+            _spriteRenderer.color = _fullAlpha;
         }
     }
 }

--- a/CookieRun/Assets/Scripts/RunState.cs
+++ b/CookieRun/Assets/Scripts/RunState.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Animations;
+using PlayerAnimationID;
 
 public class RunState : StateMachineBehaviour
 {
@@ -16,14 +17,14 @@ public class RunState : StateMachineBehaviour
         // Cookie 점프
         if(Input.GetKeyDown(KeyCode.W)) 
         {
-            animator.SetBool("Cookie_Jump", true);
+            animator.SetBool(PlayerAniID.IS_Jumping, true);
         }
 
         // Cookie 슬라이드
         // 누르고 있을 땐 계속 Slide가 진행되도록 설정한다.
         if(Input.GetKey(KeyCode.S))
         {
-            animator.SetBool("Cookie_Slide", true);
+            animator.SetBool(PlayerAniID.IS_Slide, true);
             
         }
     }
@@ -32,5 +33,4 @@ public class RunState : StateMachineBehaviour
     {
 
     }
-
 }

--- a/CookieRun/Assets/Scripts/SlideState.cs
+++ b/CookieRun/Assets/Scripts/SlideState.cs
@@ -1,3 +1,4 @@
+using PlayerAnimationID;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -19,7 +20,7 @@ public class SlideState : StateMachineBehaviour
 
         // 기본 상태 충돌 범위 및 offset
         _originColliderSize = _boxCollider2D.size;
-        _originOffset = _boxCollider2D.offset;
+        _originOffset = _boxCollider2D.offset; 
 
         // slide 충돌 범위 및 offset 
         _boxCollider2D.size = _slideSize;
@@ -30,7 +31,7 @@ public class SlideState : StateMachineBehaviour
         // S키를 때면 Slide를 멈추고 다시 달리는 상태로 전환한다.
         if (Input.GetKeyUp(KeyCode.S))
         {
-            animator.SetBool("Cookie_Slide", false);
+            animator.SetBool(PlayerAniID.IS_Slide, false);
         }
 
     }

--- a/CookieRun/Assets/Test.asset
+++ b/CookieRun/Assets/Test.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 0}
+  m_Name: Test
+  m_EditorClassIdentifier: Assembly-CSharp::Testsss
+  a: 0
+  b: 0
+  c: 0
+  d: 0

--- a/CookieRun/ProjectSettings/TagManager.asset
+++ b/CookieRun/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 2
   tags:
   - Floor
+  - Obstacles
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
1. 피격 받았을 때 SpriteRenderer을 깜박깜박 하도록 만들었다.

2. 피격 받은 이후 3초 동안 무적 상태로 만들었다.

# PR을 하기 전 체크사항
PR 전에 아래의 내용을 수행했는지 하나씩 체크해봅시다.

<!-- 체크 표시는 []에 x를 넣어 [x]로 만들면 됩니다. 자세한 건 [여기](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-task-lists)를 참고하세요 -->
- [] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
달라진 기능에는 무엇이 있는지 목록으로 작성합니다.

- 플레이어가 피격을 받았음을 알려주도록 Renderer Alpha 값을 조절했다.
- 플레이어가 피격 받았을 때 3초간 다른 장애물들에 의해 피격 받지 않는 무적 상태를 만들었다.
- 목록 3

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- 피격 받았을 때 Alpha 값을 조절했다.
>  플레이어한테 현재 캐릭터는 무적 상태임을 알려주기 위해서 사용했다.

- 피격 받았을 때 3초간 장애물과 충돌되지 않도록 만들었다.
# (선택)스크린샷
이 기능과 관련된 스크린샷을 추가합니다. (동영상 가능)

![bandicam_2023-04-21_12-21-28-137_AdobeExpress](https://user-images.githubusercontent.com/120005332/233535131-925ab28f-6ad8-4188-92a1-f5994baeb400.gif)
